### PR TITLE
fix: add cache mounts for uv to prevent Python installation in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ FROM ${FROM}
 ENV PATH=/var/lib/openstack/bin:$PATH
 RUN --mount=type=bind,source=bindep.txt,target=/bindep.txt \
     --mount=type=bind,from=ghcr.io/vexxhost/build-utils:latest,source=/bin,target=/build \
+    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/root/.local/share/uv \
     /build/install-bindep-packages


### PR DESCRIPTION
## Summary
uv/uvx downloads and installs Python to `~/.local/share/uv/python` when running bindep via uvx. This was leaving Python 3.14 files in the final image.

Add cache mounts for both:
- `/root/.cache/uv` - package cache
- `/root/.local/share/uv` - Python installations and tool environments

This prevents these files from being included in the final image layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)