### PR TITLE
fix: remove uv cache mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,4 @@ FROM ${FROM}
 ENV PATH=/var/lib/openstack/bin:$PATH
 RUN --mount=type=bind,source=bindep.txt,target=/bindep.txt \
     --mount=type=bind,from=ghcr.io/vexxhost/build-utils:latest,source=/bin,target=/build \
-    --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=cache,target=/root/.local/share/uv \
     /build/install-bindep-packages


### PR DESCRIPTION
## Summary
Remove uv cache mounts since build-utils now sets `UV_NO_CACHE=1` and `UV_PYTHON_DOWNLOADS=never`, making the cache mounts unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)