### PR TITLE
feat: add custom manager to pin build-utils digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>vexxhost/docker-atmosphere"]
+  "extends": ["local>vexxhost/docker-atmosphere"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "--mount=type=bind,from=(?<depName>[^:,\\s]+):(?<currentValue>[^@,\\s]+)(@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate custom regex manager to detect and pin the digest of `ghcr.io/vexxhost/build-utils` in the `--mount=type=bind,from=` syntax
- This ensures Docker layer cache invalidation when build-utils is updated

## Background
The `--mount=type=bind,from=image:tag` syntax within `RUN` commands isn't detected by Renovate's default Docker manager. This custom manager uses regex to match the pattern and allows Renovate to pin the digest.

Once merged, Renovate should create a follow-up PR to pin the actual digest.

## Test plan
- [ ] Merge this PR
- [ ] Verify Renovate creates a PR to pin the build-utils digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)